### PR TITLE
correct Chinese traslation mistack

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -28,8 +28,8 @@
 		]
 	},
 	"chinese" : {
-		"name" : "运动英雄",
-		"description" : "运动英雄",
+		"name" : "战役英雄",
+		"description" : "战役英雄",
 		"translations" : [
 			"translation/campaign-heroes/chinese.json"
 		]


### PR DESCRIPTION
campaign heroes means 战役英雄,  not 运动英雄（movement heroes）